### PR TITLE
Make default data consistent with Readme

### DIFF
--- a/R/bingo.R
+++ b/R/bingo.R
@@ -13,7 +13,7 @@ bingo <- function(n_cards = 1, words, n = 5) {
   stopifnot(n %% 2 == 1)
 
   if (missing(words)) {
-    words <- topics[['football']]
+    words <- topics[['open-data']]
   }
 
   words <- vet_squares(words)

--- a/R/bingo.R
+++ b/R/bingo.R
@@ -13,7 +13,7 @@ bingo <- function(n_cards = 1, words, n = 5) {
   stopifnot(n %% 2 == 1)
 
   if (missing(words)) {
-    words <- topics[['open-data']]
+    words <- topics[['football']]
   }
 
   words <- vet_squares(words)

--- a/README.Rmd
+++ b/README.Rmd
@@ -47,8 +47,8 @@ library(bingo)
 ## see some of the SuperBowl 50 squares
 tail(get_topic("football"))
 
-## make 8 bingo cards (SuperBowl 50 is current default)
-bc <- bingo(8)
+## make 8 bingo cards
+bc <- bingo(n_cards = 8, words = get_topic("football"))
 
 ## print them to PDF
 plot(bc)
@@ -78,6 +78,7 @@ tail(get_topic("open-data"))
 tail(get_topic("bad-data"))
 
 ## make a single Open Data bingo card
+## Note that "open-data" is the default topic, so you could alternatively use: bc <- bingo().
 bc <- bingo(words = get_topic("open-data"))
 
 ## make a custom bingo blend from the open and bad data squares

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tail(get_topic("bad-data"))
 #> [5] "Spelling mistakes that reek of hand-typed data"
 #> [6] "US zip codes 12345 or 90210"
 
-## make a single Open Data bingo card 
+## make a single Open Data bingo card
 ## Note that "open-data" is the default topic, so you could alternatively use: bc <- bingo().
 bc <- bingo(words = get_topic("open-data"))
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ tail(get_topic("football"))
 #> [5] "Cam's Superman shirt-opening thing"        
 #> [6] "Idle speculation it's Peyton's last game"
 
-## make 8 bingo cards (SuperBowl 50 is current default)
-bc <- bingo(8)
+## make 8 bingo cards
+bc <- bingo(n_cards = 8, words = get_topic("football"))
 
 ## print them to PDF
 plot(bc)
@@ -94,7 +94,8 @@ tail(get_topic("bad-data"))
 #> [5] "Spelling mistakes that reek of hand-typed data"
 #> [6] "US zip codes 12345 or 90210"
 
-## make a single Open Data bingo card
+## make a single Open Data bingo card 
+## Note that "open-data" is the default topic, so you could alternatively use `bc <- bingo()`.
 bc <- bingo(words = get_topic("open-data"))
 
 ## make a custom bingo blend from the open and bad data squares

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ tail(get_topic("bad-data"))
 #> [6] "US zip codes 12345 or 90210"
 
 ## make a single Open Data bingo card 
-## Note that "open-data" is the default topic, so you could alternatively use `bc <- bingo()`.
+## Note that "open-data" is the default topic, so you could alternatively use: bc <- bingo().
 bc <- bingo(words = get_topic("open-data"))
 
 ## make a custom bingo blend from the open and bad data squares


### PR DESCRIPTION
Make "football" the default topic, as stated in the SuperBowl example in the Readme. Right now, "open-data" is the default topic.